### PR TITLE
Allowing blocks free to take over tax and term endpoints as well as t…

### DIFF
--- a/src/post-select-terms-control/index.js
+++ b/src/post-select-terms-control/index.js
@@ -21,8 +21,8 @@ export default function KadencePostSelectTerms( {
 	const [ hasMore, setHasMore ] = useState( false );
 	const theValue = value;
 	useEffect( () => {
-		if( source && typeof(window.kbpData.taxonomies[source]) != 'undefined' && window.kbpData.taxonomies[source] ){
-			setTerms( Array.from(window.kbpData.taxonomies[source]) );
+		if( source && typeof(window.kadence_blocks_params.taxonomies[source]) != 'undefined' && window.kadence_blocks_params.taxonomies[source] ){
+			setTerms( Array.from(window.kadence_blocks_params.taxonomies[source]) );
 			setIsLoading( false );
 		} else {
 			const options = {
@@ -33,24 +33,24 @@ export default function KadencePostSelectTerms( {
 			setIsLoading( true );
 			apiFetch( {
 				path: addQueryArgs(
-					window.kbpData.termEndpoint,
+					window.kadence_blocks_params.termEndpoint,
 					options
 				),
 			} )
 				.then( ( taxonomyItems ) => {
 					if ( ! taxonomyItems ) {
 						setTerms( [] );
-						window.kbpData.taxonomies[source] = [];
+						window.kadence_blocks_params.taxonomies[source] = [];
 					} else {
 						setTerms( taxonomyItems );
-						window.kbpData.taxonomies[source] = taxonomyItems;
+						window.kadence_blocks_params.taxonomies[source] = taxonomyItems;
 					}
 					setIsLoading( false );
 				} )
 				.catch( () => {
 					setIsLoading( false );
 					setTerms( [] );
-					window.kbpData.taxonomies[source] = [];
+					window.kadence_blocks_params.taxonomies[source] = [];
 				} );
 		}
 	}, [ source ] );

--- a/src/taxonomy-select/index.js
+++ b/src/taxonomy-select/index.js
@@ -56,7 +56,7 @@ export default function TaxonomySelect( {
 		setIsLoading( true );
 		apiFetch( {
 			path: addQueryArgs(
-				window.kbpData.taxonomiesEndpoint,
+				window.kadence_blocks_params.taxonomiesEndpoint,
 				options
 			),
 		} )


### PR DESCRIPTION
…he taxonomies array.

Goes with https://github.com/stellarwp/kadence-blocks-pro/pull/40

A result of https://theeventscalendar.atlassian.net/browse/KAD-1315