### PR TITLE
Use pointer cursor on block setting tabs

### DIFF
--- a/src/inspector-control-tabs/editor.scss
+++ b/src/inspector-control-tabs/editor.scss
@@ -26,6 +26,7 @@ $color-gray-800: #2d3748;
 		border: 0;
 		background: #edf2f7;
 		border-top: 1px solid #cbd5e0;
+		cursor: pointer;
 		//border-bottom: 1px solid #e0e0e0;
 		svg {
 			fill: currentColor;


### PR DESCRIPTION
Resolve: [KAD-5419]

## Description
Add pointer cursor styling to inspector control tabs so tab controls present expected click affordance.

## Changes
- Add cursor pointer to tab button styles in inspector control tabs


[KAD-5419]: https://stellarwp.atlassian.net/browse/KAD-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ