### PR TITLE
Fix 1.1.7 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@kadence/components",
-	"version": "1.1.4",
+	"version": "1.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@kadence/components",
-			"version": "1.1.4",
+			"version": "1.1.7",
 			"license": "ISC",
 			"dependencies": {
 				"@floating-ui/react": "^0.26.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kadence/components",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "Shared Kadence UI components for WordPress block plugins.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Resolve: [KAD-5419]

## Summary
This updates the repository metadata to match the intended 1.1.7 release.

## Changes
- bump package.json from 1.1.6 to 1.1.7
- align package-lock.json root metadata to 1.1.7

## Why
The GitHub 1.1.7 release tag points to a commit where the tracked package metadata was left behind.

[KAD-5419]: https://stellarwp.atlassian.net/browse/KAD-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ